### PR TITLE
Right click ascend fix

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -233,10 +233,12 @@ mit.main = function() {
 
   // Game play on mouse clicks too!
   window.addEventListener('mousedown', function(e) {
+    if (e.which != 1) return;
     mit.ascend();
   }, false);
 
   window.addEventListener('mouseup', function(e) {
+    if (e.which != 1) return;
     mit.descend();
   }, false);
 


### PR DESCRIPTION
Fixed an issue where right clicking was causing pappu to ascend.

Since control display doesn't say anything about right or middle mouse button working, I added code to ignore input from those.

Might want to see if disabling the context menu is an option still. There still seems to be an issue where if you are holding left mouse, right click, and then release left mouse that pappu continues to ascend.